### PR TITLE
Added traceid as custom http header

### DIFF
--- a/foundation/web/web.go
+++ b/foundation/web/web.go
@@ -65,7 +65,7 @@ func (a *App) Handle(method string, path string, handler Handler, mw ...Middlewa
 			Now:     time.Now().UTC(),
 		}
 		ctx := context.WithValue(r.Context(), KeyValues, &v)
-
+		w.Header().Set("X-Traceid", v.TraceID)
 		if err := handler(ctx, w, r); err != nil {
 			// ??????????
 			return


### PR DESCRIPTION
Adding the traceid as a header gives the caller a way to identify a request if they need to track one down.

HTTP/1.1 200 OK
**X-Traceid: 1febd263-c452-4a20-87fe-b49b7fc181c3**
Date: Wed, 09 Sep 2020 18:49:21 GMT
Content-Length: 16
Content-Type: text/plain; charset=utf-8