### PR TITLE
Fix default for private key PEM file

### DIFF
--- a/app/sales-api/main.go
+++ b/app/sales-api/main.go
@@ -54,7 +54,7 @@ func run(log *log.Logger) error {
 		}
 		Auth struct {
 			KeyID          string `conf:"default:54bb2165-71e1-41a6-af3e-7da4a0e1e2c1"`
-			PrivateKeyFile string `conf:"default:/service/private.pem"`
+			PrivateKeyFile string `conf:"default:./private.pem"`
 			Algorithm      string `conf:"default:RS256"`
 		}
 		DB struct {


### PR DESCRIPTION
Likely caused by a copy-and-paste mistake, this change restores the
default for the private key PEM file to look in the current directory,
rather than /service/private.pem.